### PR TITLE
Improve 2D tutorial

### DIFF
--- a/tutorial/forward-2D.ipynb
+++ b/tutorial/forward-2D.ipynb
@@ -138,7 +138,7 @@
     "\n",
     "**d** is the perpendicular distance from the point $(z, x)$ to the boundary between original and extended domain;\n",
     "\n",
-    "**e** is a polinomial degree (we used cubic in this example).\n",
+    "**e** is a polynomial degree (we used cubic in this example).\n",
     "\n",
     "More details in: **Y. Gao et al. Comparison of artificial absorbing boundaries for acoustic wave equation modelling, Exploration Geophysics (2017) 76–93.** "
    ]


### PR DESCRIPTION
* some changes to the tutorial text.
* Also I have some questions: 
* In the blurb about the domain extension you note only 2nd order is implemented: 
```
The domain should be extended with absorbing layers and the halo of the space order. At this point some parameters can be defined:
nbl : int, optional
    Number of boundary layers (grid points) along sides of the grid (except top).
    Default is 0 points.
space_order : int, optional
    Finite differences spatial order.
    Default is order 2.
degree : int, optional
    Degree of the polynomial in the extension function.
    Default is 1 (linear)
alpha : float, optional
    Constant parameter of the extension function.
    Default is 0.0001

Implementation notes:
Currently, pywave implements only 2nd spatial order.
Absorbing layer is implemented with damping. The damping factor ($\eta$) is zero inside the original domain, while in the extended region it grows linearly:
$\eta(z,x) = \alpha d(z,x)^e$,
where:
d is the perpendicular distance from the point $(z, x)$ to the boundary between original and extended domain;
e is a polinomial degree (we used cubic in this example).
```

but then you show 

```
# domain extension (damping + spatial order halo)
extension = DomainExtension(nbl=50, degree=3, alpha=0.0001)
```

with degree 3? What is this degree parameter versus the other degree parameter that's passed to the `setup` method?