### PR TITLE
add sources, receivers and extend the domain using physical coordinates

### DIFF
--- a/examples/acoustic_2D.py
+++ b/examples/acoustic_2D.py
@@ -21,7 +21,9 @@ compiler = Compiler(cc="gcc", cflags="-O3 -shared")
 
 # domain extension (damping + spatial order halo)
 extension = BoundaryProcedures(
-    nbl=50,
+    # nbl=50,
+    grid_spacing = spacing,
+    length = [(750, 750), (750, 750)],
     boundary_condition=(("NN", "NN"), ("NN", "NN")),
     damping_polynomial_degree=3,
     alpha=0.0001,
@@ -31,14 +33,23 @@ extension = BoundaryProcedures(
 wavelet = Wavelet(frequency=5.0)
 
 # Source
+"""
 source = Source(kws_half_width=1, wavelet=wavelet)
+source.add(position=(270, 240))
 source.add(position=(255.5, 255.5))
-
+"""
+source = Source(kws_half_width=1, wavelet=wavelet, bbox=(0, 7680, 0, 7680))
+source.add(position=(4050, 3600))
+source.add(position=(3832.5, 3832.5))
 # receivers
+receivers = Receiver(kws_half_width=1, bbox=(0, 7680, 0, 7680))
+for i in range(512):
+    receivers.add(position=(3832.5, i*15.0))
+"""
 receivers = Receiver(kws_half_width=1)
-
 for i in range(512):
     receivers.add(position=(255.5, i))
+"""
 
 setup = Setup(
     velocity_model=velModel,


### PR DESCRIPTION
As a convenience feature, I added a little bit of code in order to allow using physical coordinates.

So now instead of using the number of grid points, you can pass the extension length. In that case, you must pass the spacing as well:

```python
# domain extension (damping + spatial order halo)
extension = BoundaryProcedures(
    # nbl=50,
    grid_spacing = spacing,
    length = [(750, 750), (750, 750)],
    boundary_condition=(("NN", "NN"), ("NN", "NN")),
    damping_polynomial_degree=3,
    alpha=0.0001,
)
```

`length` works the same as `nbl`, it can be a sequence of tuples or a single float.

Similarly, if you want to add sources and coordinates using physical coordinates, you should pass the `bbox` argument when creating `Sources()` or `Receivers()` instances:
```python
source = Source(kws_half_width=1, wavelet=wavelet, bbox=(0, 7680, 0, 7680))
source.add(position=(4050, 3600))
source.add(position=(3832.5, 3832.5))
```
In that case, the add() method will expect phyisical coordinates, using `bbox` to determine the origin position and `spacing` to locate the grid point.

The changes worked for the 2d example, but weren't extensively tested.