### PR TITLE
Replace velocity for slowness squard as parameter in the wave equation

### DIFF
--- a/simwave/kernel/backend/c_code/forward/constant_density/2d/wave.c
+++ b/simwave/kernel/backend/c_code/forward/constant_density/2d/wave.c
@@ -167,11 +167,12 @@ double forward(f_type *u, f_type *velocity, f_type *damp,
                 value += sum_x/dxSquared + sum_z/dzSquared;
 
                 //denominator with damp coefficient
-                f_type denominator = (1.0 + damp[domain_offset] * dt);
+                f_type denominator = (1.0 + damp[domain_offset] * dt / 2);
+                f_type numerator = (1.0 - damp[domain_offset] * dt / 2);
 
                 value *= (dtSquared * velocity[domain_offset] * velocity[domain_offset]) / denominator;
 
-                u[next_snapshot] = 2.0 / denominator * u[current_snapshot] - ((1.0 - damp[domain_offset] * dt) / denominator) * u[prev_snapshot] + value;
+                u[next_snapshot] = 2.0 / denominator * u[current_snapshot] - (numerator / denominator) * u[prev_snapshot] + value;
             }
         }
 
@@ -241,8 +242,11 @@ double forward(f_type *u, f_type *velocity, f_type *damp,
                         // current source point in the grid
                         size_t domain_offset = i * nx + j;
                         size_t next_snapshot = next_t * domain_size + domain_offset;
+                
+                        //denominator with damp coefficient
+                        f_type denominator = (1.0 + damp[domain_offset] * dt / 2);
 
-                        f_type value = dtSquared * velocity[domain_offset] * velocity[domain_offset] * kws * wavelet[wavelet_offset];
+                        f_type value = dtSquared * velocity[domain_offset] * velocity[domain_offset] * kws * wavelet[wavelet_offset] / denominator;
 
                         #if defined(CPU_OPENMP) || defined(GPU_OPENMP)
                         #pragma omp atomic

--- a/simwave/kernel/backend/c_code/forward/constant_density/2d/wave.c
+++ b/simwave/kernel/backend/c_code/forward/constant_density/2d/wave.c
@@ -166,11 +166,14 @@ double forward(f_type *u, f_type *velocity, f_type *damp,
 
                 value += sum_x/dxSquared + sum_z/dzSquared;
 
-                //denominator with damp coefficient
-                f_type denominator = (1.0 + damp[domain_offset] * dt / 2);
-                f_type numerator = (1.0 - damp[domain_offset] * dt / 2);
+                // parameter to be used
+                f_type slowness = 1.0 / (velocity[domain_offset] * velocity[domain_offset]);
 
-                value *= (dtSquared * velocity[domain_offset] * velocity[domain_offset]) / denominator;
+                //denominator with damp coefficient
+                f_type denominator = (1.0 + damp[domain_offset] * dt / (2 * slowness));
+                f_type numerator = (1.0 - damp[domain_offset] * dt / (2 * slowness));
+
+                value *= (dtSquared / slowness) / denominator;
 
                 u[next_snapshot] = 2.0 / denominator * u[current_snapshot] - (numerator / denominator) * u[prev_snapshot] + value;
             }
@@ -243,10 +246,13 @@ double forward(f_type *u, f_type *velocity, f_type *damp,
                         size_t domain_offset = i * nx + j;
                         size_t next_snapshot = next_t * domain_size + domain_offset;
                 
-                        //denominator with damp coefficient
-                        f_type denominator = (1.0 + damp[domain_offset] * dt / 2);
+                        // parameter to be used
+                        f_type slowness = 1.0 / (velocity[domain_offset] * velocity[domain_offset]);
 
-                        f_type value = dtSquared * velocity[domain_offset] * velocity[domain_offset] * kws * wavelet[wavelet_offset] / denominator;
+                        //denominator with damp coefficient
+                        f_type denominator = (1.0 + damp[domain_offset] * dt / (2 * slowness));
+
+                        f_type value = dtSquared / slowness * kws * wavelet[wavelet_offset] / denominator;
 
                         #if defined(CPU_OPENMP) || defined(GPU_OPENMP)
                         #pragma omp atomic

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -136,4 +136,4 @@ class TestSolution:
         # load the reference result
         u_ref = np.load(ref_file)
 
-        assert np.allclose(u, u_ref, atol=1e-05)
+        assert np.allclose(u, u_ref, atol=1e-04)


### PR DESCRIPTION
* Use the squared slowness $m$ formulation

  $m\frac{\partial^2 p}{\partial t^2} + \eta \frac{\partial p}{\partial t} - \nabla^2 p = f$.

  instead of the velocity $c$.

  $\frac{\partial^2 p}{\partial t^2} + \eta \frac{\partial p}{\partial t} - c^2 \nabla^2 p = f$.

* A missing factor of 2 was added to the denominator of the time derivative in the damping term of the absorbing boundary layer.

* The `test_solution.py` apparently uses an old reference produced with simwave itself, and maybe could be revised.