### PR TITLE
Replace `os.system` with `subprocess.run`

### DIFF
--- a/simwave/kernel/backend/compiler.py
+++ b/simwave/kernel/backend/compiler.py
@@ -1,4 +1,5 @@
-import os, subprocess
+import os
+import subprocess
 from hashlib import sha1
 
 
@@ -200,12 +201,15 @@ class Compiler:
         if os.path.exists(object_path):
             print("Shared object already compiled in:", object_path)
         else:
-            # create arguments list for `subprocess.run`: pay attention to not providing
-            # empty arguments, which the compiler will try to interpret as source filenames
-            # and consequenty fail; moreover split the compilation flags string to separate
-            # arguments to ensure proper parsing
+            # create arguments list for `subprocess.run`: pay attention to not
+            # providing empty arguments, which the compiler will try to
+            # interpret as source filenames and consequenty fail; moreover
+            # split the compilation flags string to separate arguments to
+            # ensure proper parsing
             args = [self.cc, program_path]
-            args += [flag.strip() for flag in self.cflags.split(' ') if flag.strip() != '']
+            args += [flag.strip()
+                     for flag in self.cflags.split(' ')
+                     if flag.strip() != '']
             if float_precision.strip() != '':
                 args.append("{}".format(float_precision).strip())
             if language_c.strip() != '':


### PR DESCRIPTION
Besides being recommended by the Python documentation of `os.system()` itself (https://docs.python.org/3/library/os.html#os.system), the previous implementation with `os.system()` has the issue of not handling paths with spaces, since the arguments like `program_path` and `object_path` were concatenated as strings and then incorrectly parsed by GCC in the presence of whitespace.

With `subprocess.run()`, we provide a list of arguments and the paths are handled correctly. A small commented piece of code has been introduced to build up an arguments list correctly.